### PR TITLE
Fix airdropOil transaction

### DIFF
--- a/mint_oil.ts
+++ b/mint_oil.ts
@@ -43,7 +43,7 @@ async function main() {
         mintOilTx
     );
 
-    console.log(`oil: ${mintOilTx.hash().toEncodeObject()}`);
+    console.log(`oil: ${mintOilTx.tracker().toEncodeObject()}`);
 }
 
 main()

--- a/util.ts
+++ b/util.ts
@@ -1,3 +1,4 @@
+import { H256 } from "codechain-primitives";
 import { SDK } from "codechain-sdk";
 import { Transaction } from "codechain-sdk/lib/core/classes";
 import { KeyStore } from "codechain-sdk/lib/key/KeyStore";
@@ -25,7 +26,7 @@ export async function sendTransaction(
     keyStore: KeyStore,
     seq: number,
     transaction: Transaction
-): Promise<void> {
+): Promise<H256> {
     const signedTransaction = await sdk.key.signTransaction(transaction, {
         account,
         keyStore,
@@ -33,7 +34,7 @@ export async function sendTransaction(
         seq,
         passphrase
     });
-    await sdk.rpc.chain.sendSignedTransaction(signedTransaction);
+    return await sdk.rpc.chain.sendSignedTransaction(signedTransaction);
 }
 
 export function getConfig<T>(field: string): T {


### PR DESCRIPTION
Previously, the helicopter was continuously creating airdropOil Transactions under the assumption that the transaction sent just before will be successfully completed. Therefore, any single failing transaction among transactions can cause all transactions following it to fail.
To fix this problem the functionality which recovers the last successful transaction output asset and resend based on it,  is implemented.